### PR TITLE
Fixed: display btn without reload & next-before page update btn

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "content_scripts": [
     {
       "js": ["scripts/content.js"],
-      "matches": ["https://urclass.codestates.com/codeproblem/*"]
+      "matches": ["https://urclass.codestates.com/*"]
     }
   ],
   "background": {

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,21 +1,17 @@
-const main = async () => {
+const makeGitHubBtn = ()=>{
   const url = new URL(window.location.href);
   const problemHash = url.pathname.split('/')[2];
-
+  
   const btnGroup = document.querySelector('div.item.end');
 
   const githubBtn = document.createElement('button');
   githubBtn.textContent = 'Commit To Github';
-  githubBtn.style.backgroundColor = '#ff9900';
-  githubBtn.style.color = 'white';
-  githubBtn.style.height = 'white';
-
-  githubBtn.style.padding = '10px';
-  githubBtn.style.borderRadius = '10px';
-  githubBtn.style.margin = '0px 10px';
+  githubBtn.style.cssText = 
+    'background-color : #ff9900; font-size: 15px; fontWeight: 500px; color: white;'
+    + 'border: none; padding: 10px 24px; border-radius: 6px; margin: 0px 10px;';
   githubBtn.id = 'githubBtn';
 
-  btnGroup.appendChild(githubBtn);
+  btnGroup.appendChild(githubBtn);  
 
   githubBtn.addEventListener('click', async () => {
     const scoreText = document.querySelector('div.codeproblem-console-content > div > div')?.textContent;
@@ -36,15 +32,20 @@ const main = async () => {
       alert(response.message);
       alert('커밋 완료!');
     });
-  });
-};
+  })
+}
 
-main();
+setTimeout(()=>{makeGitHubBtn()},0);
 
-setInterval(() => {
-  if (!document.getElementById('githubBtn') && window.location.href.includes('codeproblem')) {
-    main();
-  }
-}, 2000);
+window.addEventListener("locationchange", ()=>{
+  setTimeout(()=>{
+    if (document.getElementById("githubBtn")){
+      const oldBtn = document.getElementById("githubBtn");
+      oldBtn.remove();
+    }
+    
+    makeGitHubBtn();
+  },0);
+})
 
 // https://stackoverflow.com/questions/3522090/event-when-window-location-href-changes


### PR DESCRIPTION
manifest 파일 변동이 생겼습니다.
React-Router로 인하여 어쩔 수 없이 URL을 추적하는 방법을 사용하는 동시에
content_script가 주입되는 시점을 유어클래스에 접속하는 시점으로 바꾸기 위해서였습니다.

이 방법으로 리로드 없이 버튼이 생성되고, 문제가 바뀔 때마다 새로운 버튼을 생성할 수 있게 문제를 해결해줬습니다.

대신 유어클래스에서 방문하는 모든 페이지마다 DOM에 포함되지 않는 버튼이 생성되고 증발하는 이슈가 있습니다.
