### PR TITLE
Fix: Prevent a Button created in other page

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,5 +1,8 @@
 const makeGitHubBtn = ()=>{
   const url = new URL(window.location.href);
+
+  if (!url.pathname.match(/codeproblem/)) return;
+
   const problemHash = url.pathname.split('/')[2];
   
   const btnGroup = document.querySelector('div.item.end');


### PR DESCRIPTION
버튼이 생성되지만 코플릿 이외 다른 페이지에서는 parent 요소를 찾지 못합니다.
브라우저 콘솔창에 에러메시지가 다량 발생하다보니 수정해주었습니다.